### PR TITLE
feat: move healthcheck to compose

### DIFF
--- a/.ci/compose.yml
+++ b/.ci/compose.yml
@@ -1,3 +1,4 @@
+version: '3.9'
 services:
   database:
     build: ../
@@ -9,8 +10,12 @@ services:
       - ./entrypoint.sh:/entrypoint.sh:ro
       - ./init/:/docker-entrypoint-initdb.d/:ro
       - logs:/log/
-    # healthcheck:
-    #   disable: true
+    healthcheck:
+      test: /healthcheck.sh
+      interval: 5s
+      timeout: 30s
+      retries: 5
+      start_period: 0s
 
   test:
     image: alpine:3.16

--- a/.ci/compose.yml
+++ b/.ci/compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   database:
     build: ../

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,7 @@ COPY --from=setup /opt/sap /opt/sap
 # COPY --from=setup /var/lib/rpm /var/lib/rpm
 
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh
-
-HEALTHCHECK --interval=5s --timeout=30s --retries=3 CMD netstat -ltn | grep 5000
+COPY ./healthcheck.sh /healthcheck.sh
 
 EXPOSE 5000
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ docker run --rm -it --name sybase -e SA_PASSWORD=Sybase1234 -e DATABASE=hello -p
 
 ## Docker compose example
 see the [/docker-entrypoint-initdb.d/ folder example](https://github.com/cboudereau/docker-sybase/tree/main/.ci/init)
-```
+```yaml
 services:
   database:
     image: superbeeeeeee/docker-sybase
@@ -26,4 +26,7 @@ services:
       - SA_PASSWORD=Sybase1234
     volumes:
       - ./init/:/docker-entrypoint-initdb.d/
+    healthcheck:
+      test: /healthcheck.sh
+      interval: 5s
 ```

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+netstat -ltn | grep 5000 || exit 1


### PR DESCRIPTION
Adding HEALTHCHECK in Dockerfile is activated by default. The healthcheck at the scheduler level could be different for compose and kubernetes and moving the healthcheck into a script is a better trade-off. Plus, on local dev env it could slowdown the deployment since it wait for the first interval + start period.
- [x] add healthcheck.sh script
- [x] move healthcheck to compose
- [x] update README
- [x] update CI