### PR TITLE
feat: simplify healthcheck

### DIFF
--- a/.ci/compose.yml
+++ b/.ci/compose.yml
@@ -4,13 +4,13 @@ services:
     environment:
       - DATABASE=TESTDB
       - SA_PASSWORD=Sybase1234
-    entrypoint: /entrypoint.sh
+    entrypoint: entrypoint.sh
     volumes:
-      - ./entrypoint.sh:/entrypoint.sh:ro
+      - ./entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ./init/:/docker-entrypoint-initdb.d/:ro
       - logs:/log/
     healthcheck:
-      test: /healthcheck.sh
+      test: healthcheck
       interval: 5s
       timeout: 30s
       retries: 5

--- a/.ci/entrypoint.sh
+++ b/.ci/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -eu
 
-/docker-entrypoint.sh | tee /log/database.log
+docker-entrypoint.sh | tee /log/database.log

--- a/.ci/init/999-done.sh
+++ b/.ci/init/999-done.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 echo "init done" > /log/done

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,9 @@ FROM basedeps
 COPY --from=setup /opt/sap /opt/sap
 # COPY --from=setup /var/lib/rpm /var/lib/rpm
 
-COPY ./docker-entrypoint.sh /docker-entrypoint.sh
-COPY ./healthcheck.sh /healthcheck.sh
+COPY ./docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY ./healthcheck.sh /usr/local/bin/healthcheck
 
 EXPOSE 5000
 
-ENTRYPOINT [ "/docker-entrypoint.sh" ]
+ENTRYPOINT [ "docker-entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,6 @@ services:
     volumes:
       - ./init/:/docker-entrypoint-initdb.d/
     healthcheck:
-      test: /healthcheck.sh
+      test: healthcheck
       interval: 5s
 ```


### PR DESCRIPTION
Simplify healthcheck integration for docker compose.
- [x] move script to /usr/local/bin
- [x] update CI compose
- [x] update README compose example