### PR TITLE
feat/metrics example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:7 as base
 FROM base as builder
 
 ADD https://d1cuw2q49dpd0p.cloudfront.net/ASE16/Current/ASE_Suite.linuxamd64.tgz /tmp/ASE/ASE_Suite.linuxamd64.tgz
-RUN pushd /tmp/ASE && tar -xvzf /tmp/ASE_Suite.linuxamd64.tgz && rm -f ASE_Suite.linuxamd64.tgz && popd
+RUN pushd /tmp/ASE && tar -xvzf ASE_Suite.linuxamd64.tgz && rm -f ASE_Suite.linuxamd64.tgz && popd
 COPY ./sybase_response.txt /tmp/ASE
 
 FROM base as basedeps

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM centos:7 as base
 FROM base as builder
 
-ADD https://d1cuw2q49dpd0p.cloudfront.net/ASE16/Current/ASE_Suite.linuxamd64.tgz /tmp/ASE
-RUN pushd /tmp && tar -xvzf /tmp/ASE && rm -f ASE && mv ebf30399 ASE && popd
+ADD https://d1cuw2q49dpd0p.cloudfront.net/ASE16/Current/ASE_Suite.linuxamd64.tgz /tmp/ASE/ASE_Suite.linuxamd64.tgz
+RUN pushd /tmp/ASE && tar -xvzf /tmp/ASE_Suite.linuxamd64.tgz && rm -f ASE_Suite.linuxamd64.tgz && popd
 COPY ./sybase_response.txt /tmp/ASE
 
 FROM base as basedeps

--- a/examples/compose.yml
+++ b/examples/compose.yml
@@ -1,0 +1,10 @@
+services:
+  graphite:
+    image: graphiteapp/graphite-statsd
+    ports:
+      - 80:80
+      - 81:81
+      - 2003-2004:2003-2004
+      - 2023-2024:2023-2024
+      - 8125:8125/udp
+      - 8126:8126

--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -1,0 +1,15 @@
+# sybase statsd
+
+## configure send udp paket
+
+### setup
+```sql
+sp_configure 'allow sendmsg', 1
+go
+```
+
+### send metrics
+```sql
+sp_sendmsg "host.docker.internal", 8125, "sybase.hello:10|c"
+go
+```

--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -1,6 +1,15 @@
 # sybase statsd
 
-## configure send udp paket
+## run the demo
+```bash
+cd examples/observability
+
+docker compose down --remove-orphans -v --rmi local && docker compose up
+```
+
+go to [prometheus dashboard and observe the percentile metrics](http://localhost:9090/graph?g0.expr=sybase_test_table_insert&g0.tab=0&g0.stacked=1&g0.show_exemplars=0&g0.range_input=1h&g0.step_input=1)
+
+## configure send udp paket from sybase
 
 ### setup
 ```sql
@@ -8,7 +17,7 @@ sp_configure 'allow sendmsg', 1
 go
 ```
 
-### send metrics
+### send metrics example 
 ```sql
 sp_sendmsg "host.docker.internal", 8125, "sybase.hello:10|c"
 go

--- a/examples/observability/client/data.sql
+++ b/examples/observability/client/data.sql
@@ -1,0 +1,24 @@
+use TESTDB
+go
+
+/* Tradeoff : measure delay with datetime (no support for ticks nor timestamp nor true stopwatch, precision is 1/300 second). Ok to measure high latencies ie : > 1s */
+declare @s datetime
+select @s = GETUTCDATE()
+
+insert into dbo.TEST_TABLE(TEST_FIELD1) values ('1')
+insert into dbo.TEST_TABLE(TEST_FIELD1) values ('1')
+insert into dbo.TEST_TABLE(TEST_FIELD1) values ('1')
+insert into dbo.TEST_TABLE(TEST_FIELD1) values ('1')
+insert into dbo.TEST_TABLE(TEST_FIELD1) values ('1')
+
+declare @e datetime
+select @e = GETUTCDATE()
+
+declare @t integer
+select @t = DATEDIFF(MILLISECOND, @s, @e)
+
+declare @msg varchar(255)
+select @msg = "sybase.test_table.insert:" + convert(varchar, @t) + "|ms"
+exec sp_sendmsg "statsd", 8125, @msg
+
+go

--- a/examples/observability/client/schedule.sh
+++ b/examples/observability/client/schedule.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+. /opt/sap/SYBASE.sh
+
+set -u
+
+while true
+do
+    echo running $1
+    isql -Usa -S${SERVER}:5000 -P${SA_PASSWORD} -D${DATABASE} -i $1
+    sleep 1
+done

--- a/examples/observability/compose.yml
+++ b/examples/observability/compose.yml
@@ -1,0 +1,38 @@
+services:
+  prometheus:
+    image: prom/prometheus:v2.41.0
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - 9090:9090
+  
+  statsd:
+    image: prom/statsd-exporter
+    command: "--statsd.listen-udp=:8125 --web.listen-address=:9102 --log.level=debug"
+
+  database:
+    image: superbeeeeeee/docker-sybase
+    environment:
+      - DATABASE=TESTDB
+      - SA_PASSWORD=Sybase1234
+    volumes:
+      - ./database/:/docker-entrypoint-initdb.d/
+    healthcheck:
+      test: healthcheck
+      interval: 5s
+
+  client:
+    image: superbeeeeeee/docker-sybase
+    entrypoint: ["/schedule.sh", "/data.sql"]
+    environment:
+      - DATABASE=TESTDB
+      - SA_PASSWORD=Sybase1234
+      - SERVER=database
+    volumes:
+      - ./client/schedule.sh:/schedule.sh:ro
+      - ./client/data.sql:/data.sql:ro
+    depends_on:
+      database:
+        condition: service_healthy
+      statsd:
+        condition: service_started

--- a/examples/observability/compose.yml
+++ b/examples/observability/compose.yml
@@ -7,7 +7,7 @@ services:
       - 9090:9090
   
   statsd:
-    image: prom/statsd-exporter
+    image: prom/statsd-exporter:v0.23.0
     command: "--statsd.listen-udp=:8125 --web.listen-address=:9102 --log.level=debug"
 
   database:

--- a/examples/observability/database/0-allow_sp_sendmsg.sql
+++ b/examples/observability/database/0-allow_sp_sendmsg.sql
@@ -1,0 +1,4 @@
+use TESTDB
+go
+sp_configure 'allow sendmsg', 1
+go

--- a/examples/observability/database/1-table.sql
+++ b/examples/observability/database/1-table.sql
@@ -1,0 +1,18 @@
+use TESTDB
+go
+CREATE TABLE dbo.TEST_TABLE  (
+    IDROW       	numeric(18,0) IDENTITY NOT NULL,
+    TEST_FIELD1   	char(4) NOT NULL,
+    )
+LOCK DATAROWS
+WITH exp_row_size = 0, reservepagegap = 0, identity_gap = 500, DML_LOGGING = FULL
+ON [default]
+GO
+CREATE NONCLUSTERED INDEX I1_TEST_TABLE
+    ON dbo.TEST_TABLE(TEST_FIELD1)
+    ON [default]
+GO
+CREATE UNIQUE NONCLUSTERED INDEX UI_TEST_TABLE
+    ON dbo.TEST_TABLE(IDROW)
+    ON [default]
+GO

--- a/examples/observability/prometheus/prometheus.yml
+++ b/examples/observability/prometheus/prometheus.yml
@@ -1,0 +1,23 @@
+global:
+  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+
+  external_labels:
+    monitor: 'prometheus-monitor'
+
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'prometheus'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'statsd-exporter'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+
+    static_configs:
+      - targets: ['statsd:9102']

--- a/examples/observability/statsd/console.js
+++ b/examples/observability/statsd/console.js
@@ -1,0 +1,8 @@
+{
+    port: 8125
+  , backends: ["./backends/console"]
+  , debug: true
+  , dumpMessages: true
+  , console:
+      { prettyprint: true }
+}

--- a/examples/observability/statsd/repeater.js
+++ b/examples/observability/statsd/repeater.js
@@ -1,0 +1,6 @@
+{
+  port: 8125, 
+  backends: ["./backends/repeater"],
+  repeater: [ { host: 'statsd-exporter', port: 9125 } ],
+  debug: true
+}


### PR DESCRIPTION
Add an example to support metrics/timers in stored procedure / sql in sybase

- use sp_sendmsg to send udp pakets
- create a script sample to find the best trafeoffs and alternative to a common stopwatch
- integrate metrics in prometheus with statsd-exporter adapter

# Stopwatch tradeoff
Measuring delay with 2 dates is not recommended but to measure high latencies (> 1s since the precision is up to 1/300 second according to sybase documentation) without true stopwatch/timestamp, it is ok.
