### PR TITLE
conf: optimize default conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ RUN . /opt/sap/SYBASE.sh \
  && /opt/sap/ASE-16_0/bin/sqllocres -r /tmp/ASE/sqlloc1027.001-SYBASE.rs \
  && rm -rf /tmp/ASE \
  && sed -i -e 's/enable console logging = DEFAULT/enable console logging = 1/g' /opt/sap/ASE-16_0/SYBASE.cfg \
+ && sed -i -e 's/max memory = DEFAULT/max memory = 500000/g' /opt/sap/ASE-16_0/SYBASE.cfg \
+ && echo 'procedure cache size = 100000' >> /opt/sap/ASE-16_0/SYBASE.cfg \
  && sed -i -e 's/localhost/0.0.0.0/g' /opt/sap/interfaces
 
 FROM basedeps

--- a/srvbuild1027.001-SYBASE.rs
+++ b/srvbuild1027.001-SYBASE.rs
@@ -11,8 +11,8 @@ srvbuild.network_port_list: 5000
 srvbuild.application_type: USE_DEFAULT
 srvbuild.server_page_size: USE_DEFAULT
 srvbuild.master_device_physical_name: /opt/sap/data/master.dat
-srvbuild.master_device_size: USE_DEFAULT
-srvbuild.master_database_size: USE_DEFAULT
+srvbuild.master_device_size: 150
+srvbuild.master_database_size: 100
 srvbuild.errorlog: USE_DEFAULT
 srvbuild.sybsystemprocs_device_physical_name: /opt/sap/data/sysprocs.dat
 srvbuild.sybsystemprocs_device_size: USE_DEFAULT
@@ -21,8 +21,8 @@ srvbuild.sybsystemdb_device_physical_name: /opt/sap/data/sybsysdb.dat
 srvbuild.sybsystemdb_device_size: USE_DEFAULT
 srvbuild.sybsystemdb_database_size: USE_DEFAULT
 srvbuild.tempdb_device_physical_name: /opt/sap/data/tempdbdev.dat
-srvbuild.tempdb_device_size: USE_DEFAULT
-srvbuild.tempdb_database_size: USE_DEFAULT
+srvbuild.tempdb_device_size: 250
+srvbuild.tempdb_database_size: 250
 #srvbuild.default_backup_server: SYBASE_BS
 #srvbuild.addl_cmdline_parameters: 
 srvbuild.shmem: /opt/sap/ASE-16_0


### PR DESCRIPTION
According to internal tests, the configuration should be changed as bellow:

srvbuild.master_device_size: 150
srvbuild.master_database_size: 100
srvbuild.tempdb_device_size: 250
srvbuild.tempdb_database_size: 250

max memory = 500000
procedure cache size = 100000