### PR TITLE
feat: disable non sa logins during recovery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN . /opt/sap/SYBASE.sh \
  && /opt/sap/ASE-16_0/bin/sqllocres -r /tmp/ASE/sqlloc1027.001-SYBASE.rs \
  && rm -rf /tmp/ASE \
  && sed -i -e 's/enable console logging = DEFAULT/enable console logging = 1/g' /opt/sap/ASE-16_0/SYBASE.cfg \
+ && sed -i -e 's/enable logins during recovery = DEFAULT/enable logins during recovery = 0/g' /opt/sap/ASE-16_0/SYBASE.cfg \
  && sed -i -e 's/max memory = DEFAULT/max memory = 500000/g' /opt/sap/ASE-16_0/SYBASE.cfg \
  && echo 'procedure cache size = 100000' >> /opt/sap/ASE-16_0/SYBASE.cfg \
  && sed -i -e 's/localhost/0.0.0.0/g' /opt/sap/interfaces

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ docker run --rm -it --name sybase -e SA_PASSWORD=Sybase1234 -e DATABASE=hello -p
 ```
 
 ## Docker compose example
-see the [/docker-entrypoint-initdb.d/ folder example](https://github.com/cboudereau/docker-sybase/tree/main/.ci/init)
+- [Basic example](./examples/basic/compose.yml)
+- [Full example](./.ci/compose.yml)
 ```yaml
 services:
   database:
@@ -28,6 +29,8 @@ services:
       - SA_PASSWORD=Sybase1234
     volumes:
       - ./init/:/docker-entrypoint-initdb.d/
+    ports:
+      - 5000:5000
     healthcheck:
       test: healthcheck
       interval: 5s

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,13 +25,13 @@ run_init_files () {
   done
 }
 
-echo "starting sybase..."
+echo "starting docker-sybase..."
 ${SYBASE}/${SYBASE_ASE}/install/RUN_SYBASE &
 
 while ! netstat -ltn | grep 5000; do   
   sleep 0.1
 done
-echo "sybase started"
+echo "docker-sybase started"
 
 if  [[ ! -f "/.initialized" ]]; then
   DATABASE=${DATABASE-}

--- a/examples/basic/compose.yml
+++ b/examples/basic/compose.yml
@@ -1,0 +1,14 @@
+services:
+  database:
+    image: superbeeeeeee/docker-sybase
+    pull_policy: always
+    environment:
+      - DATABASE=hello
+      - SA_PASSWORD=Sybase1234
+    volumes:
+      - ./init/:/docker-entrypoint-initdb.d/
+    ports:
+      - 5000:5000
+    healthcheck:
+      test: healthcheck
+      interval: 5s

--- a/examples/basic/init/1_hello-world.sh
+++ b/examples/basic/init/1_hello-world.sh
@@ -1,0 +1,1 @@
+echo "hello world"


### PR DESCRIPTION
Sybase server port is opened while it is not completely setup (with multiple devices setup).

Client using the image should not use SA account but instead use a non SA account so that the login will work when sybase becomes ready.

- [x] set "enable logins during recovery" cf to 0
- [x] fix log by replacing "sybase started" to "docker-sybase started"
- [x] add basic docker-compose example
- [x] clean README