### PR TITLE
deps: replace centos by rockylinux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7 as base
+FROM rockylinux:9 as base
 FROM base as builder
 
 ADD https://d1cuw2q49dpd0p.cloudfront.net/ASE16/Current/ASE_Suite.linuxamd64.tgz /tmp/ASE/ASE_Suite.linuxamd64.tgz

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,14 @@ RUN pushd /tmp/ASE && tar -xvzf ASE_Suite.linuxamd64.tgz && rm -f ASE_Suite.linu
 COPY ./sybase_response.txt /tmp/ASE
 
 FROM base as basedeps
-RUN dnf install libnsl* -y \
- && yum update -y \
- && yum install -y libaio net-tools nc \
+RUN yum update -y \
+ && yum install -y libaio net-tools nc libnsl.x86_64 \
  && yum clean all
 
 FROM basedeps as setup
 COPY --from=builder /tmp/ASE /tmp/ASE
 
-RUN /tmp/ASE/setup.bin -DAGREE_TO_SAP_LICENSE=true -i silent -f /tmp/ASE/sybase_response.txt || cat /opt/sap/log/ASE_Suite.log \
+RUN /tmp/ASE/setup.bin -DAGREE_TO_SAP_LICENSE=true -i silent -f /tmp/ASE/sybase_response.txt \
  && rm -rf /tmp/ASE
 
 FROM setup as install

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,15 @@ RUN pushd /tmp/ASE && tar -xvzf ASE_Suite.linuxamd64.tgz && rm -f ASE_Suite.linu
 COPY ./sybase_response.txt /tmp/ASE
 
 FROM base as basedeps
-RUN yum update -y \
+RUN dnf install libnsl* -y \
+ && yum update -y \
  && yum install -y libaio net-tools nc \
  && yum clean all
 
 FROM basedeps as setup
 COPY --from=builder /tmp/ASE /tmp/ASE
 
-RUN /tmp/ASE/setup.bin -DAGREE_TO_SAP_LICENSE=true -i silent -f /tmp/ASE/sybase_response.txt \
+RUN /tmp/ASE/setup.bin -DAGREE_TO_SAP_LICENSE=true -i silent -f /tmp/ASE/sybase_response.txt || cat /opt/sap/log/ASE_Suite.log \
  && rm -rf /tmp/ASE
 
 FROM setup as install


### PR DESCRIPTION
closes #17 

- [x] use rockylinux instead of centos since RHEL EOL issues and a true RHEL drop-in solution.
- [x] add missing libnsl dependency for sybase 